### PR TITLE
chore: `1.2.0` release

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -42,7 +42,7 @@ jobs:
       - name: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: install
@@ -66,7 +66,7 @@ jobs:
       - name: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: install

--- a/package-lock.json
+++ b/package-lock.json
@@ -524,6 +524,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
       "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -548,6 +549,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
       "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -592,6 +594,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
       "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -686,6 +689,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
       "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -807,6 +811,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
       "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -946,6 +951,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
       "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1025,6 +1031,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
       "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1257,6 +1264,45 @@
       },
       "engines": {
         "node": "^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
+      "integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2575,163 +2621,6 @@
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
     },
-    "node_modules/@stablelib/aead": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
-      "integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==",
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/binary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
-      "dependencies": {
-        "@stablelib/int": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/bytes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
-      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ==",
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/chacha": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
-      "integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/chacha20poly1305": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
-      "integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/aead": "^1.0.1",
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/chacha": "^1.0.1",
-        "@stablelib/constant-time": "^1.0.1",
-        "@stablelib/poly1305": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
-      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==",
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/ed25519": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
-      "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
-      "dependencies": {
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/sha512": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/hash": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
-    },
-    "node_modules/@stablelib/hkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
-      "integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/hash": "^1.0.1",
-        "@stablelib/hmac": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/hmac": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
-      "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/constant-time": "^1.0.1",
-        "@stablelib/hash": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
-    },
-    "node_modules/@stablelib/keyagreement": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
-      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/bytes": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/poly1305": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
-      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/constant-time": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/random": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/sha256": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
-      "integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/hash": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/sha512": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
-      "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/hash": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/wipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
-    },
-    "node_modules/@stablelib/x25519": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
-      "integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/keyagreement": "^1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -3053,9 +2942,9 @@
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.3.tgz",
-      "integrity": "sha512-57uv0FW4L6H/tmkb1kS2nG41MDguyDgZbGR58nkDUd1TO/HydyiTByVOhFzIxgN331cnY/1G1rMaKqncgdnOFA==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.18.0.tgz",
+      "integrity": "sha512-i/olu/IwYtBiWYqyfNUMxq4b6QS5dv+ZVVGmLT2buRwdH6MGETN0Bx3/z6rXJzd1sNd+QL07fxhSFxCekL57tA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -3066,11 +2955,11 @@
         "@walletconnect/keyvaluestorage": "1.1.1",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.0.4",
+        "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.17.3",
-        "@walletconnect/utils": "2.17.3",
+        "@walletconnect/types": "2.18.0",
+        "@walletconnect/utils": "2.18.0",
         "@walletconnect/window-getters": "1.0.1",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0",
@@ -3199,22 +3088,17 @@
       }
     },
     "node_modules/@walletconnect/relay-auth": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.0.4.tgz",
-      "integrity": "sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz",
+      "integrity": "sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==",
+      "license": "MIT",
       "dependencies": {
-        "@stablelib/ed25519": "^1.0.2",
-        "@stablelib/random": "^1.0.1",
+        "@noble/curves": "1.8.0",
+        "@noble/hashes": "1.7.0",
         "@walletconnect/safe-json": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
-        "tslib": "1.14.1",
         "uint8arrays": "^3.0.0"
       }
-    },
-    "node_modules/@walletconnect/relay-auth/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
@@ -3230,19 +3114,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/sign-client": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.3.tgz",
-      "integrity": "sha512-OzOWxRTfVGCHU3OOF6ibPkgPfDpivFJjuknfcOUt9PYWpTAv6YKOmT4cyfBPhc7llruyHpV44fYbykMcLIvEcg==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.18.0.tgz",
+      "integrity": "sha512-oUjlRIsbHxMSRif2WvMRdvm6tMsQjMj07rl7YVcKVvZ1gF1/9GcbJPjzL/U87fv8qAQkVhIlbEg2vHaVYf6J/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.17.3",
+        "@walletconnect/core": "2.18.0",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.17.3",
-        "@walletconnect/utils": "2.17.3",
+        "@walletconnect/types": "2.18.0",
+        "@walletconnect/utils": "2.18.0",
         "events": "3.3.0"
       }
     },
@@ -3260,9 +3144,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
-      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.18.0.tgz",
+      "integrity": "sha512-g0jU+6LUuw3E/EPAQfHNK2xK/95IpRfz68tdNAFckLmefZU6kzoE1mIM1SrPJq8rT9kUPp6/APMQE+ReH2OdBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -3274,31 +3158,55 @@
       }
     },
     "node_modules/@walletconnect/utils": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.3.tgz",
-      "integrity": "sha512-tG77UpZNeLYgeOwViwWnifpyBatkPlpKSSayhN0gcjY1lZAUNqtYslpm4AdTxlrA3pL61MnyybXgWYT5eZjarw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.18.0.tgz",
+      "integrity": "sha512-6AUXIcjSxTHGRsTtmUP/oqudtwRILrQqrJsH3jS5T28FFDzZt7+On6fR4mXzi64k4nNYeWg1wMCGLEdtxmGbZQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ethersproject/hash": "5.7.0",
         "@ethersproject/transactions": "5.7.0",
-        "@stablelib/chacha20poly1305": "1.0.1",
-        "@stablelib/hkdf": "1.0.1",
-        "@stablelib/random": "1.0.2",
-        "@stablelib/sha256": "1.0.1",
-        "@stablelib/x25519": "1.0.3",
+        "@noble/ciphers": "1.2.1",
+        "@noble/curves": "1.8.1",
+        "@noble/hashes": "1.7.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
         "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.0.4",
+        "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.17.3",
+        "@walletconnect/types": "2.18.0",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "detect-browser": "5.3.0",
         "elliptic": "6.6.1",
         "query-string": "7.1.3",
         "uint8arrays": "3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/bn.js": {
@@ -14760,16 +14668,16 @@
     },
     "packages/walletkit": {
       "name": "@reown/walletkit",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.17.3",
+        "@walletconnect/core": "2.18.0",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.17.3",
-        "@walletconnect/types": "2.17.3",
-        "@walletconnect/utils": "2.17.3"
+        "@walletconnect/sign-client": "2.18.0",
+        "@walletconnect/types": "2.18.0",
+        "@walletconnect/utils": "2.18.0"
       },
       "devDependencies": {
         "@ethersproject/wallet": "5.7.0"

--- a/packages/walletkit/package.json
+++ b/packages/walletkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reown/walletkit",
   "description": "WalletKit for WalletConnect Protocol",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": false,
   "author": "Reown, Inc.",
   "homepage": "https://github.com/reown-com/",
@@ -31,13 +31,13 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/core": "2.17.3",
+    "@walletconnect/core": "2.18.0",
     "@walletconnect/jsonrpc-provider": "1.0.14",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.1.2",
-    "@walletconnect/sign-client": "2.17.3",
-    "@walletconnect/types": "2.17.3",
-    "@walletconnect/utils": "2.17.3"
+    "@walletconnect/sign-client": "2.18.0",
+    "@walletconnect/types": "2.18.0",
+    "@walletconnect/utils": "2.18.0"
   },
   "devDependencies": {
     "@ethersproject/wallet": "5.7.0"

--- a/packages/walletkit/src/controllers/engine.ts
+++ b/packages/walletkit/src/controllers/engine.ts
@@ -17,6 +17,9 @@ export class Engine extends IWalletKitEngine {
       metadata: this.client.metadata,
       signConfig: this.client.signConfig,
     });
+    this.signClient.core.eventClient.init().catch((error) => {
+      this.client.logger.warn(error);
+    });
   };
 
   public pair: IWalletKitEngine["pair"] = async (params) => {

--- a/packages/walletkit/test/sign.spec.ts
+++ b/packages/walletkit/test/sign.spec.ts
@@ -1029,4 +1029,26 @@ describe("Sign Integration", () => {
       await disconnect(dapp.core);
     });
   });
+
+  it("should send core init event when walletkit initializes", async () => {
+    process.env.IS_VITEST = false as any;
+    const core = new Core({ ...TEST_CORE_OPTIONS, telemetryEnabled: false });
+    let initCalled = false;
+    expect(initCalled).to.be.false;
+    // @ts-expect-error - accessing private properties
+    core.eventClient.sendEvent = async (payload: any) => {
+      initCalled = true;
+      expect(payload).toBeDefined();
+      expect(payload.length).to.eql(1);
+      expect(payload[0].props.event).to.eql("INIT");
+      expect(payload[0].props.properties.client_id).to.eql(await core.crypto.getClientId());
+    };
+    await WalletKit.init({
+      core,
+      name: "wallet",
+      metadata: TEST_METADATA,
+    });
+    expect(initCalled).to.be.true;
+    process.env.IS_VITEST = true as any;
+  });
 });


### PR DESCRIPTION
## Description
- Bumps `@walletconnect` deps to latest (`2.18.0`)
- Bumps minor version for release `1.2.0`
- Sends init event on WK initialization as `Core` no longer does it automatically

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
