### PR TITLE
chore: `1.2.3` release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/walletkit"
   ],
-  "version": "1.2.2"
+  "version": "1.2.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3033,9 +3033,9 @@
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.19.1.tgz",
-      "integrity": "sha512-rMvpZS0tQXR/ivzOxN1GkHvw3jRRMlI/jRX5g7ZteLgg2L0ZcANsFvAU5IxILxIKcIkTCloF9TcfloKVbK3qmw==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.19.2.tgz",
+      "integrity": "sha512-iu0mgLj51AXcKpdNj8+4EdNNBd/mkNjLEhZn6UMc/r7BM9WbmpPMEydA39WeRLbdLO4kbpmq4wTbiskI1rg+HA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -3049,8 +3049,8 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.1",
-        "@walletconnect/utils": "2.19.1",
+        "@walletconnect/types": "2.19.2",
+        "@walletconnect/utils": "2.19.2",
         "@walletconnect/window-getters": "1.0.1",
         "es-toolkit": "1.33.0",
         "events": "3.3.0",
@@ -3205,19 +3205,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/sign-client": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.19.1.tgz",
-      "integrity": "sha512-OgBHRPo423S02ceN3lAzcZ3MYb1XuLyTTkKqLmKp/icYZCyRzm3/ynqJDKndiBLJ5LTic0y07LiZilnliYqlvw==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.19.2.tgz",
+      "integrity": "sha512-a/K5PRIFPCjfHq5xx3WYKHAAF8Ft2I1LtxloyibqiQOoUtNLfKgFB1r8sdMvXM7/PADNPe4iAw4uSE6PrARrfg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.19.1",
+        "@walletconnect/core": "2.19.2",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.1",
-        "@walletconnect/utils": "2.19.1",
+        "@walletconnect/types": "2.19.2",
+        "@walletconnect/utils": "2.19.2",
         "events": "3.3.0"
       }
     },
@@ -3235,9 +3235,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.19.1.tgz",
-      "integrity": "sha512-XWWGLioddH7MjxhyGhylL7VVariVON2XatJq/hy0kSGJ1hdp31z194nHN5ly9M495J9Hw8lcYjGXpsgeKvgxzw==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.19.2.tgz",
+      "integrity": "sha512-/LZWhkVCUN+fcTgQUxArxhn2R8DF+LSd/6Wh9FnpjeK/Sdupx1EPS8okWG6WPAqq2f404PRoNAfQytQ82Xdl3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -3249,9 +3249,9 @@
       }
     },
     "node_modules/@walletconnect/utils": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.19.1.tgz",
-      "integrity": "sha512-aOwcg+Hpph8niJSXLqkU25pmLR49B8ECXp5gFQDW5IeVgXHoOoK7w8a79GBhIBheMLlIt1322sTKQ7Rq5KzzFg==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.19.2.tgz",
+      "integrity": "sha512-VU5CcUF4sZDg8a2/ov29OJzT3KfLuZqJUM0GemW30dlipI5fkpb0VPenZK7TcdLPXc1LN+Q+7eyTqHRoAu/BIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "1.2.1",
@@ -3263,12 +3263,11 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.1",
+        "@walletconnect/types": "2.19.2",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "bs58": "6.0.0",
         "detect-browser": "5.3.0",
-        "elliptic": "6.6.1",
         "query-string": "7.1.3",
         "uint8arrays": "3.1.0",
         "viem": "2.23.2"
@@ -3320,27 +3319,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@walletconnect/utils/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "license": "MIT"
-    },
-    "node_modules/@walletconnect/utils/node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/eventemitter3": {
@@ -3993,7 +3971,8 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true
     },
     "node_modules/bs58": {
       "version": "6.0.0",
@@ -7368,6 +7347,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -7389,6 +7369,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -9738,12 +9719,14 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -14921,16 +14904,16 @@
     },
     "packages/walletkit": {
       "name": "@reown/walletkit",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.19.1",
+        "@walletconnect/core": "2.19.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.19.1",
-        "@walletconnect/types": "2.19.1",
-        "@walletconnect/utils": "2.19.1"
+        "@walletconnect/sign-client": "2.19.2",
+        "@walletconnect/types": "2.19.2",
+        "@walletconnect/utils": "2.19.2"
       },
       "devDependencies": {
         "@ethersproject/wallet": "5.7.0"

--- a/packages/walletkit/package.json
+++ b/packages/walletkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reown/walletkit",
   "description": "WalletKit for WalletConnect Protocol",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": false,
   "author": "Reown, Inc.",
   "homepage": "https://github.com/reown-com/",
@@ -31,13 +31,13 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/core": "2.19.1",
+    "@walletconnect/core": "2.19.2",
     "@walletconnect/jsonrpc-provider": "1.0.14",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.1.2",
-    "@walletconnect/sign-client": "2.19.1",
-    "@walletconnect/types": "2.19.1",
-    "@walletconnect/utils": "2.19.1"
+    "@walletconnect/sign-client": "2.19.2",
+    "@walletconnect/types": "2.19.2",
+    "@walletconnect/utils": "2.19.2"
   },
   "devDependencies": {
     "@ethersproject/wallet": "5.7.0"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   define: {
     "process.env.IS_VITEST": true,
+    "process.env.DISABLE_GLOBAL_CORE": true,
   },
   test: {
     testTimeout: 800_000,


### PR DESCRIPTION
- updated `@walletconnect` dependencies to latest (`v2.19.2`)
- updates `walletkit` version for patch release `1.2.3` 