### PR TITLE
feat: add CTA assistant workflow

### DIFF
--- a/.github/workflows/cta.yml
+++ b/.github/workflows/cta.yml
@@ -1,0 +1,22 @@
+name: "CTA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cta_assistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CTA Assistant"
+        uses: WalletConnect/actions/github/cta-assistant@9fd44c01c5f8c169349f8822efc93dd08821a628
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add automated Copyright Transfer Agreement (CTA) assistant workflow
- Uses WalletConnect CTA assistant action pinned to specific commit hash
- Creates `cta-signatures` branch for storing signature data

## Test plan
- [ ] Verify workflow triggers on pull requests and issue comments
- [ ] Test CTA signature collection process
- [ ] Confirm integration with existing CI/CD pipeline